### PR TITLE
node shapes: Add all shapes based on graphviz infosrc

### DIFF
--- a/dot/syntaxes/dot.tmLanguage
+++ b/dot/syntaxes/dot.tmLanguage
@@ -73,7 +73,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(box|polygon|ellipse|circle|point|egg|triangle|plaintext|diamond|trapezium|parallelogram|house|pentagon|hexagon|septagon|octagon|doublecircle|doubleoctagon|tripleoctagon|invtriangle|invtrapezium|invhouse|Mdiamond|Msquare|Mcircle|rect|rectangle|none|note|tab|folder|box3d|component|max|min|same)\b</string>
+			<string>\b(box|polygon|ellipse|oval|circle|point|egg|triangle|plaintext|plain|diamond|trapezium|parallelogram|house|pentagon|hexagon|septagon|octagon|doublecircle|doubleoctagon|tripleoctagon|invtriangle|invtrapezium|invhouse|Mdiamond|Msquare|Mcircle|rect|rectangle|square|star|none|underline|cylinder|note|tab|folder|box3d|component|promoter|cds|terminator|utr|primersite|restrictionsite|fivepoverhang|threepoverhang|noverhang|assembly|signature|insulator|ribosite|rnastab|proteasesite|proteinstab|rpromoter|rarrow|larrow|lpromoter)\b</string>
 			<key>name</key>
 			<string>variable.other.dot</string>
 		</dict>


### PR DESCRIPTION
I think it makes sense to base the list of shapes off the shapelist in
the src: https://gitlab.com/graphviz/graphviz/blob/master/doc/infosrc/shapelist

This modifies the tmLanguage file to reflect all known shapes.