### PR TITLE
feat(graphviz):  Switch to @hpcc-js/wasm from Viz.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 A vscode extension that provides language support and live preview for the Graphviz format.
 
-The preview uses the [Viz.js](https://github.com/mdaines/viz.js/) library.
+The preview uses the [@hpcc-js/wasm](https://github.com/hpcc-systems/hpcc-js-wasm) library.
 
 The extension can be activated in two ways
 
@@ -95,5 +95,5 @@ On Windows, just omit the `sudo` instruction.
 
 ## Credits
 
-* The preview uses <https://github.com/mdaines/viz.js/> .
+* The preview uses <https://github.com/hpcc-systems/hpcc-js-wasm> .
 * The syntax highlight/snippets support is based on <https://github.com/Stephanvs/vscode-graphviz> .

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@hpcc-js/wasm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@hpcc-js/wasm/-/wasm-1.0.0.tgz",
+      "integrity": "sha512-ke4M2uWcN3pUpZhuAietI3jPzVGb44/qepCuvWVELqXT/TM2/MtS5gqRGVjizPuo8WFIyGHLeEdnW1ZJFkVkkw=="
+    },
     "@types/mocha": {
       "version": "2.2.48",
       "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.48.tgz",
@@ -11,9 +16,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-6.14.0.tgz",
-      "integrity": "sha512-6tQyh4Q4B5pECcXBOQDZ5KjyBIxRZGzrweGPM47sAYTdVG4+7R+2EGMTmp0h6ZwgqHrFRCeg2gdhsG9xXEl2Sg==",
+      "version": "10.17.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.49.tgz",
+      "integrity": "sha512-PGaJNs5IZz5XgzwJvL/1zRfZB7iaJ5BydZ8/Picm+lUNYoNO9iVTQkVy5eUh0dZDrx3rBOIs3GCbCRmMuYyqwg==",
       "dev": true
     },
     "@types/tmp": {
@@ -259,7 +264,7 @@
     },
     "commander": {
       "version": "2.3.0",
-      "resolved": "http://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz",
       "integrity": "sha1-/UMOiJgy7DU7ms0d4hfBHLPu+HM=",
       "dev": true
     },
@@ -295,7 +300,7 @@
     },
     "debug": {
       "version": "2.2.0",
-      "resolved": "http://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
       "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
       "dev": true,
       "requires": {
@@ -951,13 +956,13 @@
       "dependencies": {
         "commander": {
           "version": "0.6.1",
-          "resolved": "http://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz",
           "integrity": "sha1-+mihT2qUXVTbvlDYzbMyDp47GgY=",
           "dev": true
         },
         "mkdirp": {
           "version": "0.3.0",
-          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz",
           "integrity": "sha1-G79asbqCevI1dRQ0kEJkVfSB/h4=",
           "dev": true
         }
@@ -1068,13 +1073,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -1083,7 +1088,7 @@
     },
     "mocha": {
       "version": "2.5.3",
-      "resolved": "http://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.5.3.tgz",
       "integrity": "sha1-FhvlvetJZ3HrmzV0UFC2IrWu/Fg=",
       "dev": true,
       "requires": {
@@ -1101,7 +1106,7 @@
     },
     "ms": {
       "version": "0.7.1",
-      "resolved": "http://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
       "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
       "dev": true
     },
@@ -1677,9 +1682,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.1.4.tgz",
-      "integrity": "sha512-JZHJtA6ZL15+Q3Dqkbh8iCUmvxD3iJ7ujXS+fVkKnwIVAdHc5BJTDNM0aTrnr2luKulFjU7W+SRhDZvi66Ru7Q==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.3.tgz",
+      "integrity": "sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==",
       "dev": true
     },
     "unc-path-regex": {
@@ -1861,11 +1866,6 @@
           }
         }
       }
-    },
-    "viz.js": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/viz.js/-/viz.js-2.0.0.tgz",
-      "integrity": "sha512-OzUX9NWBc4u9QjFjVZYXGf7evbDHD8D9YcnVk9qEgrpYzWmeX+9Cov0n2KxbIidRRAef8OXwGrPfwnWubasKQg=="
     },
     "vscode": {
       "version": "1.1.30",

--- a/package.json
+++ b/package.json
@@ -119,15 +119,15 @@
     "test": "node ./node_modules/vscode/bin/test"
   },
   "devDependencies": {
-    "typescript": "^3.1.4",
+    "typescript": "^4.1.3",
     "vscode": "^1.1.30",
     "mocha": "^2.3.3",
-    "@types/node": "^6.0.40",
+    "@types/node": "^10",
     "@types/mocha": "^2.2.32",
     "@types/tmp": "^0.0.33"
   },
   "dependencies": {
-    "viz.js": "^2.0.0",
+    "@hpcc-js/wasm": "^1.0.0",
     "opn": "^6.0.0",
     "tmp": "^0.0.33"
   }

--- a/src/GraphvizPreviewGenerator.ts
+++ b/src/GraphvizPreviewGenerator.ts
@@ -1,6 +1,5 @@
 import { ExtensionContext, TextDocument, window, ViewColumn, Uri, WebviewPanel, workspace, Disposable } from "vscode";
-const { Module, render } = require('viz.js/full.render.js');
-let Viz = require("viz.js");
+import { graphviz } from "@hpcc-js/wasm";
 import * as path from "path";
 import { SvgExporter } from "./SvgExporter";
 import { OpenInBrowser } from "./OpenInBrowser";
@@ -113,7 +112,7 @@ export class GraphvizPreviewGenerator extends Disposable {
 
     toSvg(doc: TextDocument): Thenable<string> | string {
         let text = doc.getText();
-        return new Viz({Module, render}).renderString(text);
+        return graphviz.dot(text);
     }
 
     private async getPreviewHtml(previewPanel: PreviewPanel, doc: TextDocument): Promise<string> {

--- a/src/SvgExporter.ts
+++ b/src/SvgExporter.ts
@@ -1,7 +1,6 @@
 import fs = require('fs');
 import { Uri, window, workspace } from 'vscode';
-let Viz = require("viz.js");
-const { Module, render } = require('viz.js/full.render.js');
+import { graphviz } from "@hpcc-js/wasm";
 
 export class SvgExporter {
     constructor() {
@@ -31,7 +30,7 @@ export class SvgExporter {
     protected async renderSvgString(documentUri: Uri): Promise<string> {
         let doc = await workspace.openTextDocument(documentUri);
         let graphVizText = doc.getText();
-        let svg = await new Viz({ Module, render }).renderString(graphVizText);
+        let svg = await graphviz.dot(graphVizText);
         return svg;
     }
 }


### PR DESCRIPTION
This will bump the Graphviz version to the latest stable (2.44.1)

Signed-off-by: Gordon Smith <GordonJSmith@gmail.com>